### PR TITLE
fix: settings tab vertical scrollbar has to be always visible

### DIFF
--- a/src/ui/WdgSettings.qml
+++ b/src/ui/WdgSettings.qml
@@ -57,6 +57,7 @@ Item {
         id: scrollView
         clip: true
 
+        ScrollBar.vertical.policy: ScrollBar.AlwaysOn
         anchors.fill: parent
         anchors.margins: Stylesheet.defaultMargin
         //anchors.topMargin: styleSectionSeparatorHeight / 2


### PR DESCRIPTION
fix settings tab vertical scrollbar that has to be always visible