### PR TITLE
fix: after setting decimals to 4 digits totals remain with 2 digits

### DIFF
--- a/src/ui/WdgInvoice.qml
+++ b/src/ui/WdgInvoice.qml
@@ -2840,7 +2840,7 @@ Item {
 
     function getRoundingDecimals() {
         if (invoice.json && invoice.json.document_info.decimals_amounts !== null) {
-            if (invoice.json.document_info.decimals_amount >= 0) {
+            if (invoice.json.document_info.decimals_amounts >= 0) {
                 return invoice.json.document_info.decimals_amounts
             }
         }


### PR DESCRIPTION
Fixed the issue where the decimals digits didn't adjust with the number of digits in the settings